### PR TITLE
Make RevisionNumber nullable.

### DIFF
--- a/UnifiLabs.Samples.ProjectAnalytics/Entities/Revision.cs
+++ b/UnifiLabs.Samples.ProjectAnalytics/Entities/Revision.cs
@@ -15,7 +15,7 @@ namespace UnifiLabs.Samples.ProjectAnalytics.Entities {
 
         [JsonProperty("Notes")] public string Notes { get; set; }
 
-        [JsonProperty("RevisionNumber")] public long RevisionNumber { get; set; }
+        [JsonProperty("RevisionNumber")] public long? RevisionNumber { get; set; }
 
         [JsonProperty("Status")] public long Status { get; set; }
 


### PR DESCRIPTION
An exception is thrown because the response contains a null value for `data["projectInfo"]["revisionInfo"]["revisions"][0]["revisionNumber"]`.